### PR TITLE
New docs cleanup

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Run bandit
       #uses: ioggstream/bandit-report-artifacts@v0.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -23,7 +23,7 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout Project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We need to fetch with a depth of 2 for pull_request so we can do HEAD^2
         fetch-depth: 2
@@ -66,7 +66,7 @@ jobs:
       base_cov: ${{ steps.get_base.outputs.base_cov }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: badges
         path: badges
@@ -134,7 +134,7 @@ jobs:
       PIP_DOWNLOAD_CACHE: ${{ github.workspace }}/../.pip_download_cache
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -299,7 +299,7 @@ jobs:
       markdown: ${{ steps.url.outputs.markdown }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: badges
         path: badges

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -78,7 +78,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: badges
         path: badges

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         git config --global core.autocrlf false
         git config --global core.eol lf
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -64,7 +64,7 @@ jobs:
           echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
           echo ${{ env.VERSION }}
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Pystache
 
 
 This updated fork of Pystache is currently tested on Python 3.6+ and in
-Conda, on Linux, Macos, and Windows (Python 2.7 support has been removed).
+Conda, on Linux, Macos, and Windows (Python 2.7 is no longer supported).
 
 |logo|
 
@@ -346,7 +346,7 @@ License <https://creativecommons.org/licenses/by-sa/3.0/deed.en_US>`__.
     :target: https://www.python.org/downloads/
     :alt: Python
 
-.. |pre| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white
+.. |pre| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&amp;logoColor=white
    :target: https://github.com/pre-commit/pre-commit
    :alt: pre-commit
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,0 +1,6 @@
+Change history (recent)
+=======================
+
+.. include:: ../../CHANGELOG.rst
+
+For older changes through v0.6.0 see the HISTORY.md file in the repository.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,6 +37,7 @@ __version__ = pkg_resources.get_distribution('pystache').version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_git',
     'sphinxcontrib.apidoc',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',

--- a/docs/source/dev/generate-changelog.rst
+++ b/docs/source/dev/generate-changelog.rst
@@ -14,7 +14,7 @@ To generate a (full) changelog from the repository root, run:
 
 .. code-block:: bash
 
-    (venv) $ gitchangelog
+    (venv) $ gitchangelog > CHANGELOG.rst
 
 You can use ``gitchangelog`` to create the changelog automatically.  It
 examines git commit history and uses custom "filters" to produce its
@@ -74,10 +74,10 @@ modifier::
 
 See the current `.gitchangelog.rc`_ in the repo for more details.
 
-Read more about ``gitchangelog`` here_.
+Read more about gitchangelog_.
 
 .. _.gitchangelog.rc: https://github.com/VCTLabs/redis-ipc/blob/develop/.gitchangelog.rc
-.. _here: https://github.com/sarnold/gitchangelog
+.. _gitchangelog: https://github.com/sarnold/gitchangelog
 
 
 Git Tags

--- a/docs/source/gh/images/logo_phillips_small.png
+++ b/docs/source/gh/images/logo_phillips_small.png
@@ -1,0 +1,1 @@
+../../../../gh/images/logo_phillips_small.png

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,13 @@
 Welcome to the pystache documentation!
 ======================================
 
+.. git_commit_detail::
+    :branch:
+    :commit:
+    :sha_length: 10
+    :uncommitted:
+    :untracked:
+
 .. toctree::
    :maxdepth: 4
    :caption: Contents:
@@ -10,7 +17,6 @@ Welcome to the pystache documentation!
    dev/pre-commit-config
    dev/pre-commit-usage
    api/modules
-
 
 Indices and tables
 ==================

--- a/docs/source/readme_include.rst
+++ b/docs/source/readme_include.rst
@@ -4,3 +4,6 @@
 
 .. include:: ../../README.rst
   :start-after: inclusion-marker-2
+
+
+.. include:: changelog.rst

--- a/pystache/context.py
+++ b/pystache/context.py
@@ -168,17 +168,17 @@ class ContextStack(object):
 
         Arguments:
 
-          *context: zero or more dictionaries, ContextStack instances, or objects
+          :context: zero or more dictionaries, ContextStack instances, or objects
             with which to populate the initial context stack.  None
-            arguments will be skipped.  Items in the *context list are
+            arguments will be skipped.  Items in the context list are
             added to the stack in order so that later items in the argument
             list take precedence over earlier items.  This behavior is the
-            same as the constructor's.
+            same as the constructor.
 
-          **kwargs: additional key-value data to add to the context stack.
-            As these arguments appear after all items in the *context list,
+          :kwargs: additional key-value data to add to the context stack.
+            As these arguments appear after all items in the context list,
             in the case of key conflicts these values take precedence over
-            all items in the *context list.  This behavior is the same as
+            all items in the context list.  This behavior is the same as
             the constructor's.
 
         """
@@ -211,9 +211,9 @@ class ContextStack(object):
 
         Arguments:
 
-          name: a dotted or non-dotted name.
+          :name: a dotted or non-dotted name.
 
-          default: the value to return if name resolution fails at any point.
+          :default: the value to return if name resolution fails at any point.
             Defaults to the empty string per the Mustache spec.
 
         This method queries items in the stack in order from last-added

--- a/pystache/renderer.py
+++ b/pystache/renderer.py
@@ -38,8 +38,8 @@ class Renderer(object):
     >>> print(renderer.render('{{>partial}}', {'thing': 'world'}))
     Hello, world!
 
-    To customize string coercion (e.g. to render False values as ''), one can
-    subclass this class.  For example:
+    To customize string coercion (e.g. to render False values as ``''``), one can
+    subclass this class.  For example::
 
         class MyRenderer(Renderer):
             def str_coerce(self, val):
@@ -425,7 +425,7 @@ class Renderer(object):
         """
         Arguments:
 
-          render_func: a function that accepts a RenderEngine and ContextStack
+          :render_func: a function that accepts a RenderEngine and ContextStack
             instance and returns a template rendering as a unicode string.
 
         """
@@ -449,23 +449,23 @@ class Renderer(object):
 
         Arguments:
 
-          template: a template string that is unicode or a byte string,
+          :template: a template string that is unicode or a byte string,
             a ParsedTemplate instance, or another object instance.  In the
             final case, the function first looks for the template associated
             to the object by calling this class's get_associated_template()
             method.  The rendering process also uses the passed object as
             the first element of the context stack when rendering.
 
-          *context: zero or more dictionaries, ContextStack instances, or objects
+          :context: zero or more dictionaries, ContextStack instances, or objects
             with which to populate the initial context stack.  None
-            arguments are skipped.  Items in the *context list are added to
+            arguments are skipped.  Items in the context list are added to
             the context stack in order so that later items in the argument
             list take precedence over earlier items.
 
-          **kwargs: additional key-value data to add to the context stack.
-            As these arguments appear after all items in the *context list,
+          :kwargs: additional key-value data to add to the context stack.
+            As these arguments appear after all items in the context list,
             in the case of key conflicts these values take precedence over
-            all items in the *context list.
+            all items in the context list.
 
         """
         if is_string(template):

--- a/pystache/tests/test___init__.py
+++ b/pystache/tests/test___init__.py
@@ -20,7 +20,7 @@ class InitTests(unittest.TestCase):
 
     def test___all__(self):
         """
-        Test that "from pystache import *" works as expected.
+        Test that "from pystache import ``*``" works as expected.
 
         """
         actual = set(GLOBALS_PYSTACHE_IMPORTED) - set(GLOBALS_INITIAL)

--- a/pystache/tests/test_renderer.py
+++ b/pystache/tests/test_renderer.py
@@ -290,7 +290,7 @@ class RendererTests(unittest.TestCase, AssertStringMixin):
 
     def test_render__context_and_kwargs(self):
         """
-        Test render(): passing a context and **kwargs.
+        Test render(): passing a context and kwargs.
 
         """
         renderer = self._renderer()
@@ -299,7 +299,7 @@ class RendererTests(unittest.TestCase, AssertStringMixin):
 
     def test_render__kwargs_and_no_context(self):
         """
-        Test render(): passing **kwargs and no context.
+        Test render(): passing kwargs and no context.
 
         """
         renderer = self._renderer()
@@ -307,7 +307,7 @@ class RendererTests(unittest.TestCase, AssertStringMixin):
 
     def test_render__context_and_kwargs__precedence(self):
         """
-        Test render(): **kwargs takes precedence over context.
+        Test render(): kwargs takes precedence over context.
 
         """
         renderer = self._renderer()
@@ -315,7 +315,7 @@ class RendererTests(unittest.TestCase, AssertStringMixin):
 
     def test_render__kwargs_does_not_modify_context(self):
         """
-        Test render(): passing **kwargs does not modify the passed context.
+        Test render(): passing kwargs does not modify the passed context.
 
         """
         context = {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ cov =
 
 doc =
     sphinx
+    sphinx_git
     recommonmark
     sphinx_rtd_theme
     sphinxcontrib-apidoc

--- a/tox.ini
+++ b/tox.ini
@@ -135,22 +135,29 @@ commands =
 [testenv:docs]
 skip_install = true
 allowlist_externals =
+    bash
     make
 
 deps =
     {[base]deps}
     .[doc]
+
+commands_pre =
+    # need to generate version info in a fresh checkout
+    bash -c '[[ -f pystache/_version.py ]] || python setup.py egg_info'
 
 commands = make -C docs html
 
 [testenv:docs-lint]
 skip_install = true
 allowlist_externals =
-    make
+    {[testenv:docs]allowlist_externals}
 
 deps =
-    {[base]deps}
-    .[doc]
+    {[testenv:docs]deps}
+
+commands_pre =
+    {[testenv:docs]commands_pre}
 
 commands = make -C docs linkcheck
 


### PR DESCRIPTION
I was working on a docs build for another project and i noticed sphinx was kicking out 50+ docstring warnings plus a logo warning so now that is squeaky-clean.  This also pulls in another sphinx extension for git info and another rst include for the changelog.  Looks a lot nicer now...  Oh, and a version bump for the workflow checkout action (cleans up a github alert)