### PR TITLE
Remove versioningit because it makes packaging difficult for Linux distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+v0.6.5 (2023-08-19)
+-------------------
+
+Other
+~~~~~
+
+- Keep changelog up to date manually as I don't know how to autogenerate. [Thomas David Baker]
+- Remove versioningit because it makes packaging hard for Linux distrubutions. [Thomas David Baker]
+
 v0.6.4 (2023-08-13)
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -48,13 +48,6 @@ the spec tests; PyYAML can still be used (see the Develop section).
 
 Official support for Python 2 has ended with Pystache version 0.6.0.
 
-
-.. note:: This project uses versioningit_ to generate and maintain the
-          version file, which only gets included in the sdist/wheel
-          packages. In a fresh clone, running any of the tox_ commands
-          should generate the current version file.
-
-.. _versioningit: https://github.com/jwodder/versioningit
 .. _tox: https://github.com/tox-dev/tox
 
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,10 +21,8 @@ requirements:
     - pip
     - python
     - setuptools
-    - versioningit
   run:
     - python >=3.7
-    - versioningit
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools>=42",
-    "versioningit >= 1.1.1",
 ]
 
 build-backend = "setuptools.build_meta"
@@ -64,14 +63,3 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
-
-[tool.versioningit.next-version]
-method = "smallest"
-
-[tool.versioningit.format]
-distance = "{next_version}.dev{distance}"
-dirty = "{version}+d{build_date:%Y%m%d}"
-distance-dirty = "{next_version}.dev{distance}"
-
-[tool.versioningit.write]
-file = "pystache/_version.py"

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ PLATFORM =
 [base]
 deps =
     pip>=21.1
-    versioningit
 
 [testenv]
 passenv = CI,PYTHON,PYTHONIOENCODING


### PR DESCRIPTION
- Remove versioningit because it makes packaging hard for Linux distrubutions
- Remove versioningit because it makes packaging hard for Linux distrubutions
