### PR TITLE
fix: fail on unmatched tags

### DIFF
--- a/pystache/parser.py
+++ b/pystache/parser.py
@@ -237,17 +237,12 @@ class _Parser(object):
     def parse(self, template):
         """
         Parse a template string starting at some index.
-
         This method uses the current tag delimiter.
 
         Arguments:
-
           template: a unicode string that is the template to parse.
 
-          index: the index at which to start parsing.
-
         Returns:
-
           a ParsedTemplate instance.
 
         """
@@ -336,6 +331,10 @@ class _Parser(object):
                 node = self._make_interpolation_node(tag_type, tag_key, leading_whitespace)
 
             parsed_template.add(node)
+
+        # Some open/close tags were mismatched.
+        if states:
+            raise ParsingError('Tag mismatch.')
 
         # Avoid adding spurious empty strings to the parse tree.
         if start_index != len(template):

--- a/pystache/tests/test_parser.py
+++ b/pystache/tests/test_parser.py
@@ -33,6 +33,7 @@ class ParseTestCase(unittest.TestCase):
         """
         ts = [
             '<div>{{>A}}</div>',
+            '{{#A}}<div> some text</div>',
             '{{^A}}<div> some text</div>{{/A}}',
             '{{#A}} {{^B}} {{/B}} {{/A}}',
             '{{#A}} {{^B}} {{/B}} {{/A}} {{#C}} {{/C}}',
@@ -53,4 +54,4 @@ class ParseTestCase(unittest.TestCase):
         for t in ts:
             with self.subTest(template=t):
                 with self.assertRaises(ParsingError):
-                    parse(t)
+                    parse(t, raise_on_mismatch=True)

--- a/pystache/tests/test_parser.py
+++ b/pystache/tests/test_parser.py
@@ -8,19 +8,49 @@ Unit tests of parser.py.
 import unittest
 
 from pystache.defaults import DELIMITERS
-from pystache.parser import _compile_template_re as make_re
+from pystache.parser import _compile_template_re as make_re, parse, ParsingError
 
 
 class RegularExpressionTestCase(unittest.TestCase):
-
     """Tests the regular expression returned by _compile_template_re()."""
 
     def test_re(self):
         """
         Test getting a key from a dictionary.
-
         """
         re = make_re(DELIMITERS)
         match = re.search("b  {{test}}")
 
         self.assertEqual(match.start(), 1)
+
+
+class ParseTestCase(unittest.TestCase):
+    """Tests the parse() function."""
+
+    def test_parse_okay(self):
+        """
+        Test parsing templates in the cases there are no errors.
+        """
+        ts = [
+            '<div>{{>A}}</div>',
+            '{{^A}}<div> some text</div>{{/A}}',
+            '{{#A}} {{^B}} {{/B}} {{/A}}',
+            '{{#A}} {{^B}} {{/B}} {{/A}} {{#C}} {{/C}}',
+        ]
+        for t in ts:
+            with self.subTest(template=t):
+                parse(t)
+
+    def test_parse_fail(self):
+        """
+        Test parsing templates in the cases there are errors.
+        """
+        ts = [
+            '{{#A}}<div> some text</div>',
+            '{{#A}}<div> some text</div>{{/A}} <div> TEXT </div> {{/B}}',
+            '{{#A}} {{#B}} {{/A}} {{/B}}',
+        ]
+        for t in ts:
+            with self.subTest(template=t):
+                with self.assertRaises(ParsingError):
+                    parse(t)


### PR DESCRIPTION
While playing with this library I noticed that for the tags that were not closed or not properly matched the parsing didn't fail.
I have added a few test cases to demonstrate this behavior. 

PS: I used mustache playground to run & compare the results:
https://jgonggrijp.gitlab.io/wontache/playground.html